### PR TITLE
Update moviepy import for moviepy>=2.0.0

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import argparse
 import io
 from typing import Any, Dict, List, Tuple, Union
 
-import moviepy.editor as mp
+import moviepy as mp
 import numpy as np
 import streamlit as st
 import torch

--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ def wav_to_black_mp4(wav_path: str, output_path: str, fps: int = 25) -> None:
     duration: float = waveform.shape[1] / sample_rate
     audio = mp.AudioFileClip(wav_path)
     black_clip = mp.ColorClip((256, 250), color=(0, 0, 0), duration=duration)
-    final_clip = black_clip.set_audio(audio)
+    final_clip = black_clip.with_audio(audio)
     final_clip.write_videofile(output_path, fps=fps)
 
 


### PR DESCRIPTION
The streamlit app currently errors out as it tries to import `moviepy.editor` which was removed in version 2.0.0: [Changelog v.10.2 ... v2.0.0](https://github.com/Zulko/moviepy/compare/v1.0.2...v2.0.0#diff-c3ee2c034e72d4bd054cbd2791283fdc9effe0b899ed81c55198f19699ddad28).

I adjusted the import statement in `app.py` to reflect those changes and the streamlit app now runs as it should.