### PR TITLE
fix(word-timing): decode each word's tokens together so UTF-8 survives

### DIFF
--- a/crisperwhisper/longform/token_lcs.py
+++ b/crisperwhisper/longform/token_lcs.py
@@ -15,7 +15,11 @@ import numpy as np
 from crisperwhisper.longform.base import LongformConfig, make_chunks
 from crisperwhisper.prompt import strip_prompt_artifacts
 from crisperwhisper.result import ChunkResult, WordTimestamp
-from crisperwhisper.word_timing import group_tokens_into_words, monotonize_words
+from crisperwhisper.word_timing import (
+    decode_word_texts,
+    group_tokens_into_words,
+    monotonize_words,
+)
 
 if TYPE_CHECKING:
     from crisperwhisper.interfaces import EngineProtocol
@@ -247,9 +251,10 @@ def token_lcs_transcribe_with_word_timestamps(
     # Segment the merged token sequence into words and time each word from
     # its source-chunk Viterbi alignment via the provenance tags.
     merged_pieces = [engine.tokenizer.decode([t]) for t in merged_tokens]
-    merged_word_groups, merged_word_texts = group_tokens_into_words(
+    merged_word_groups, _ = group_tokens_into_words(
         merged_tokens, merged_pieces,
     )
+    merged_word_texts = decode_word_texts(engine, merged_tokens, merged_word_groups)
 
     def _global_time(pos: int, which: str):
         _, chunk_idx, orig_idx = merged[pos]

--- a/crisperwhisper/word_timing.py
+++ b/crisperwhisper/word_timing.py
@@ -80,7 +80,15 @@ def group_tokens_into_words(
     token_ids: List[int],
     token_pieces: List[str],
 ) -> Tuple[List[List[int]], List[str]]:
-    """Group token indices into words, returning ``(word_token_indices, word_texts)``."""
+    """Group token indices into words.
+
+    Returns ``(word_token_indices, word_texts)``. Callers need the first
+    value: contiguous token-index spans, excluding special and space-only
+    tokens. The second value is concatenated per-token pieces, used for
+    grouping / tests only. Those strings can contain U+FFFD for UTF-8
+    byte-pair words (e.g. space+æ); production word text comes from
+    :func:`decode_word_texts`.
+    """
     word_token_indices: List[List[int]] = []
     word_texts: List[str] = []
 
@@ -112,6 +120,28 @@ def group_tokens_into_words(
 
     flush()
     return word_token_indices, word_texts
+
+
+def decode_word_texts(
+    engine,
+    token_ids: List[int],
+    word_token_indices: List[List[int]],
+) -> List[str]:
+    """Decode each word's token span as a group.
+
+    Per-token ``tokenizer.decode([id])`` is required for word *boundaries*
+    (leading space), but UTF-8 byte-pair pieces (e.g. space+æ → ids 690+99)
+    only reconstitute when decoded together.  Concatenating per-token
+    strings yields U+FFFD for those words.
+
+    Timed continuation feeds ``wt.word`` back as the next chunk's context,
+    so this is decode quality, not display.
+    """
+    texts: List[str] = []
+    for idxs in word_token_indices:
+        ids = [int(token_ids[i]) for i in idxs]
+        texts.append(engine.decode_tokens(ids, skip_special=True).strip())
+    return texts
 
 
 # ---------------------------------------------------------------------------
@@ -504,9 +534,10 @@ def extract_word_timings(
     # Tokens -> word groups (mirrors group_token_rows_into_words in
     # evaluation/timing_extractors.py).
     tok_pieces = [engine.tokenizer.decode([t]) for t in gen_ids]
-    word_token_indices, word_texts = group_tokens_into_words(gen_ids, tok_pieces)
+    word_token_indices, _ = group_tokens_into_words(gen_ids, tok_pieces)
     if not word_token_indices:
         return []
+    word_texts = decode_word_texts(engine, gen_ids, word_token_indices)
 
     # Frame window for alignment. By default we use the FULL encoder window and
     # let the Viterbi blank states absorb the silent (padding) region.

--- a/tests/test_transformers_backend.py
+++ b/tests/test_transformers_backend.py
@@ -160,3 +160,13 @@ class TestTransformersTokenizerParity:
         pieces = [tf_engine.tokenizer.decode([t]) for t in ids]
         _, words = group_tokens_into_words(ids, pieces)
         assert words == ["hello", "world"]
+
+    def test_grouped_decode_reconstitutes_danish_ae(self, tf_engine):
+        from crisperwhisper.word_timing import decode_word_texts, group_tokens_into_words
+
+        ids = tf_engine.encode_text(" ændre")
+        pieces = [tf_engine.tokenizer.decode([t]) for t in ids]
+        word_idx, _ = group_tokens_into_words(ids, pieces)
+        texts = decode_word_texts(tf_engine, ids, word_idx)
+        assert texts == ["ændre"]
+        assert "\ufffd" not in texts[0]

--- a/tests/test_word_timestamps.py
+++ b/tests/test_word_timestamps.py
@@ -14,6 +14,7 @@ import pytest
 from crisperwhisper.result import WordTimestamp
 from crisperwhisper.word_timing import (
     blank_logp_from_mel_energy,
+    decode_word_texts,
     extract_word_timings,
     group_tokens_into_words,
     token_logp_from_attention,
@@ -156,6 +157,52 @@ class TestTokenGrouping:
         pieces = ["<ctx>", "<ectx>", " hi", "[verbatim_1]", "there", "<eot>"]
         word_idx, word_text = group_tokens_into_words(tok_ids, pieces)
         assert word_text == ["hi", "there"]
+
+
+class _StubUtf8Engine:
+    """Mimic Whisper byte-pair decode: ids 690+99 are space+æ only together."""
+
+    def decode_tokens(self, token_ids, skip_special=True):
+        ids = [int(t) for t in token_ids]
+        out = []
+        i = 0
+        while i < len(ids):
+            if ids[i : i + 2] == [690, 99]:
+                out.append(" æ")
+                i += 2
+                continue
+            tid = ids[i]
+            if tid == 690:
+                out.append(" \ufffd")
+            elif tid == 99:
+                out.append("\ufffd")
+            elif tid == 273:
+                out.append("nd")
+            elif tid == 265:
+                out.append("re")
+            else:
+                out.append("")
+            i += 1
+        return "".join(out)
+
+
+class TestGroupedWordDecode:
+    def test_space_ae_byte_pair_is_one_word_span(self):
+        tok_ids = [690, 99, 273, 265]
+        pieces = [" \ufffd", "\ufffd", "nd", "re"]
+        word_idx, concat_text = group_tokens_into_words(tok_ids, pieces)
+        assert word_idx == [[0, 1, 2, 3]]
+        # Concatenated pieces are expected to be broken; grouped decode
+        # reconstitutes the word in test_grouped_decode_reconstitutes_ae.
+        assert concat_text == ["\ufffd\ufffdndre"]
+
+    def test_grouped_decode_reconstitutes_ae(self):
+        tok_ids = [690, 99, 273, 265]
+        pieces = [" \ufffd", "\ufffd", "nd", "re"]
+        word_idx, _ = group_tokens_into_words(tok_ids, pieces)
+        texts = decode_word_texts(_StubUtf8Engine(), tok_ids, word_idx)
+        assert texts == ["ændre"]
+        assert "\ufffd" not in texts[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Word timestamps rebuilt each word by concatenating `tokenizer.decode([id])` for every token. Whisper BPE splits some UTF-8 characters across tokens (Danish word-initial **æ** is ids `690`+`99`; many CJK characters are the same pattern). Those pieces only reconstitute when decoded **together**, so the word string became U+FFFD.

Grouping still uses the per-token pieces for leading-space boundaries. Each word's token span is then decoded as a group via `decode_tokens`.

This is not display-only. Timed continuation feeds confirmed `wt.word` back as the next chunk's context, so longform text can shift beyond the previously broken words. The untimed path already decoded whole sequences and was never affected.

## Repro audio


**Danish:**    
[special-danish-test.wav](https://github.com/user-attachments/files/31195310/special-danish-test.wav)
short read of æ-initial words (`ældre`, `ændre`, `ægte`, `ændring`). Middle words æ / ø / å were already fine.

Setup used here:  CT2 turbo/large , word_timestamps=True  

## Before / after

### Danish ( [special-danish-test.wav](https://github.com/user-attachments/files/31195310/special-danish-test.wav) , turbo CT2 verbatim)

| | text |
|---|---|
| **Before** | Min ��ldre søster vil ��ndre køkkenet. Det er en ��gte stor ��ndring. Næste lørdag åbner hun vinduet, hører radio og prøver farverne af, så det ikke ser forfærdeligt ud. |
| **After** | Min ældre søster vil ændre køkkenet. Det er en ægte stor ændring. Næste lørdag åbner hun vinduet, hører radio og prøver farverne af, så det ikke ser forfærdeligt ud. |

| word | before | after |
|---|---|---|
| ældre | U+FFFD U+FFFD + `ldre` | ældre |
| ændre | U+FFFD U+FFFD + `ndre` | ændre |
| ægte | U+FFFD U+FFFD + `gte` | ægte |
| ændring | U+FFFD U+FFFD + `ndring` | ændring |

`Næste`, `forfærdeligt`, `søster`, `åbner` were already correct (æ/ø/å not split at the word start). Segment U+FFFD count: **8 → 0**.

## NOTE:

This also fixes some of my Japanese texts, where kanji such as 複製 / 移動 / 操作 showed as U+FFFD.